### PR TITLE
Add trailing slash to path domains.

### DIFF
--- a/AcsfToolsUtils.php
+++ b/AcsfToolsUtils.php
@@ -33,6 +33,12 @@ class AcsfToolsUtils extends DrushCommands {
         if (!isset($sites[$site_details['name']])) {
           $sites[$site_details['name']] = $site_details;
         }
+
+        // Path domains need a trailing slash to be recognized as a drush alias.
+        if (FALSE !== strpos($domain, '/')) {
+          $domain = rtrim($domain, '/') . '/';
+        }
+
         $sites[$site_details['name']]['domains'][] = $domain;
       }
     }


### PR DESCRIPTION
Before:

```
=> Running command on dev.example.com/las-vegas

In Settings.php line 149:

  Missing $settings['hash_salt'] in settings.php.


cache:rebuild [--cache-clear [CACHE-CLEAR]] [--no-cache-clear] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--notify [NOTIFY]] [--xh-link XH-LINK] [--druplicon] [--] <command>


=> Running command on dev.example.com/newyork

In Settings.php line 149:

  Missing $settings['hash_salt'] in settings.php.


cache:rebuild [--cache-clear [CACHE-CLEAR]] [--no-cache-clear] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--notify [NOTIFY]] [--xh-link XH-LINK] [--druplicon] [--] <command>
```

After

```
=> Running command on dev.example.com/las-vegas/
 [success] Cache rebuild complete.

=> Running command on dev.example.com/newyork/
 [success] Cache rebuild complete.
```