### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "symfony/yaml": "^3.0"
+    "symfony/yaml": "^4.0"
   }
 }


### PR DESCRIPTION
Drupal 9 requires Symfony 4. We are currently locked at Symfony 3.
```
 - Conclusion: don't install acquia/acsf-tools 9.0.0
    - drupal/core-recommended 9.0.0 requires symfony/yaml v4.4.9 -> satisfiable by symfony/yaml[v4.4.9].
```

This updates the requirement to use Symfony 4.