### PR TITLE
#118 Support two symfony/yaml major versions, 3.x and 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=5.6.0",
-    "symfony/yaml": "^3.0",
+    "symfony/yaml": "^3.0 | ^4.0",
     "composer/installers": "~1.0"
   },
   "autoload": {


### PR DESCRIPTION
The use of it is pretty minimal on the codebase.

Please see #118 