### PR TITLE
Resolves issues with sql restore command, and adds some error reporting.

### DIFF
--- a/AcsfToolsCommands.php
+++ b/AcsfToolsCommands.php
@@ -643,9 +643,9 @@ class AcsfToolsCommands extends AcsfToolsUtils implements SiteAliasManagerAwareI
           continue;
         }
 
-        $result = json_decode($sql_connect_process->getOutput(), TRUE);
+        $result = $sql_connect_process->getOutput();
 
-        if (!empty($result) && array_key_exists('object', $result)) {
+        if (!empty($result)) {
           $sql_drop_process = Drush::drush($self, 'sql-drop', $arguments, $options);
           $sql_drop_process_exit_code = $sql_drop_process->run();
 
@@ -656,7 +656,9 @@ class AcsfToolsCommands extends AcsfToolsUtils implements SiteAliasManagerAwareI
             continue;
           }
 
-          $shell_execution_process = Drush::shell($result['object'] . ' < ' . $source_file);
+          // Ensure that we do not have any carriage returns in our output.
+          $result = str_replace(array("\r", "\n"), '', $result);
+          $shell_execution_process = Drush::shell('cat ' . $source_file . ' | ' . $result);
           $exit_code_shell = $shell_execution_process->run();
 
           if ($exit_code_shell !== 0) {
@@ -665,6 +667,9 @@ class AcsfToolsCommands extends AcsfToolsUtils implements SiteAliasManagerAwareI
               ->writeln("\n=> The command failed to execute for the site $domain.");
             continue;
           }
+        }
+        else {
+          $this->logger()->error("Skipping restore because result of sql-connect was empty.");
         }
 
         // Remove the temporary decompressed dump


### PR DESCRIPTION
Running with drush 10 revealed that the `$result` variable was not returning json as the existing code expects.

`var_dump`'ing that string reveals, for my lando instance.

```
string(90) "mysql --user=drupal8 --password=drupal8 --database=drupal8 --host=database --port=3306 -A
```

This was previously verified in a factory setting, too.

Additionally, on our factory, the command still failed to run due to newline characters so some attempt is made to strip those.

Finally, the failure of the command had been hidden for some time due to it failing silently, so I have added some reporting on failure.