### PR TITLE
Allow version 7 of symfony/yaml to support Drupal 11 installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=8.0",
-    "symfony/yaml": "^6.2",
+    "symfony/yaml": "^6.2 || ^7.2",
     "composer/installers": "^1.0 || ^2.0",
     "ext-zip": "^1.15",
     "phpmailer/phpmailer": "^6.1"


### PR DESCRIPTION
**Motivation**
Fixes #170 

**Proposed changes**
Alloweds symfony/yaml version 7 and version 6
