### PR TITLE
#187 Ensure technical domain is first on MEO.

### DIFF
--- a/AcsfToolsUtils.php
+++ b/AcsfToolsUtils.php
@@ -258,6 +258,14 @@ class AcsfToolsUtils extends DrushCommands {
       throw new \RuntimeException("Multi-site not defined in $multisite_file_path");
     }
 
+    // Sort to ensure technical domains are first.
+    uksort(
+      $sites,
+      function (string $a, string $b): int {
+        return !str_ends_with($a, '.acquia-sites.com') <=> !str_ends_with($b, '.acquia-sites.com');
+      },
+    );
+
     $site_details = [];
     foreach ($sites as $site_name => $site_path) {
       // If site path already exists, just add the domain to the list of domains.


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #187 where `acsf-tools` can choose the technical domain over a custom domain as MEO presents domains in alphabetical order.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Sort the domains with technical first.

Technically it does this using a check for domain ending with `.acquia-sites.com`. Theoretically you could add a custom domain that ends in `.acquia-sites.com` which would mean the second item in the list would be an `.acquia-sites.com` domain and they _could_ be the wrong way round. But that feels an unliekly edge case that we probably don't need to worry too much about.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Applying this as a filter in `getDomain`, but that feels more complex and affects ACSF where the ordering can be controlled to get the desired domain.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Use this against an MEO site with custom domains. As the domains are sorted alphabetically, add a domain will be sorted before the site name, e.g. `a.example.com` will be before `mysite`'s technical domain.